### PR TITLE
Add metadata upload script example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,14 @@
       "program": "${workspaceFolder}/src/calculate-cids.js",
       "skipFiles": ["<node_internals>/**"],
       "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Pinata Upload Metadata",
+      "program": "${workspaceFolder}/src/upload-metadata.js",
+      "skipFiles": ["<node_internals>/**"],
+      "envFile": "${workspaceFolder}/.env"
     }
   ]
 }

--- a/metadata/0
+++ b/metadata/0
@@ -1,0 +1,13 @@
+{
+  "name": "#1",
+  "description": "The number 1.",
+  "image": "ipfs://QmZPnX4481toHABEtvKFoCWoVuzFFQRBiA5QR2Cij9pjon",
+  "seller_fee_basis_points": 400,
+  "fee_recipient": "",
+  "attributes": [
+    {
+      "trait_type": "Number",
+      "value": "One"
+    }
+  ]
+}

--- a/metadata/1
+++ b/metadata/1
@@ -1,0 +1,8 @@
+{
+  "name": "#2",
+  "description": "The number 2.",
+  "image": "ipfs://QmazpAaWf3Bb4qhSW9PnQXfj2URbQwdNbZvDr77RbwH7xb",
+  "seller_fee_basis_points": 400,
+  "fee_recipient": "",
+  "attributes": [{ "trait_type": "Number", "value": "Two" }]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "nft-pinata-bulk-upload",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "axios": "^0.24.0"
+      },
       "devDependencies": {
         "@pinata/sdk": "^1.1.23",
+        "base-path-converter": "^1.0.2",
         "bottleneck": "^2.19.5",
         "dotenv": "^10.0.0",
+        "form-data": "^4.0.0",
         "fs-extra": "^10.0.0",
         "ipfs-only-hash": "^4.0.0",
         "recursive-fs": "^2.1.0"
@@ -75,6 +80,29 @@
         "form-data": "^2.3.3",
         "is-ipfs": "^0.6.0",
         "recursive-fs": "^1.1.2"
+      }
+    },
+    "node_modules/@pinata/sdk/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@pinata/sdk/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/@pinata/sdk/node_modules/recursive-fs": {
@@ -206,12 +234,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/base-path-converter": {
@@ -511,7 +538,6 @@
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -528,17 +554,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -1896,6 +1922,26 @@
         "recursive-fs": "^1.1.2"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "recursive-fs": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/recursive-fs/-/recursive-fs-1.1.2.tgz",
@@ -2014,12 +2060,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "base-path-converter": {
@@ -2245,17 +2290,16 @@
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "dev": true
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
   },
   "homepage": "https://github.com/Coderrob/nft-pinata-bulk-upload#readme",
   "devDependencies": {
+    "axios": "^0.24.0",
     "@pinata/sdk": "^1.1.23",
+    "base-path-converter": "^1.0.2",
     "bottleneck": "^2.19.5",
     "dotenv": "^10.0.0",
+    "form-data": "^4.0.0",
     "fs-extra": "^10.0.0",
-    "recursive-fs": "^2.1.0",
-    "ipfs-only-hash": "^4.0.0"
+    "ipfs-only-hash": "^4.0.0",
+    "recursive-fs": "^2.1.0"
   },
   "dependencies": {}
 }

--- a/src/upload-metadata.js
+++ b/src/upload-metadata.js
@@ -1,0 +1,36 @@
+require("dotenv").config();
+const { PINATA_API_KEY, PINATA_API_SECRET } = process.env;
+const axios = require("axios");
+const fs = require("fs-extra");
+const recursive = require("recursive-fs");
+const FormData = require("form-data");
+const basePathConverter = require("base-path-converter");
+const PINATA_API_PINFILETOIPFS =
+  "https://api.pinata.cloud/pinning/pinFileToIPFS";
+
+(async () => {
+  try {
+    const folderPath = "metadata";
+    const { files } = await recursive.read(folderPath);
+    if (files?.length <= 0) {
+      return;
+    }
+    const data = new FormData();
+    files.forEach((path) => {
+      data.append("file", fs.createReadStream(path), {
+        filepath: basePathConverter(folderPath, path),
+      });
+    });
+    await axios.post(PINATA_API_PINFILETOIPFS, data, {
+      maxBodyLength: "Infinity",
+      headers: {
+        "Content-Type": `multipart/form-data; boundary=${data._boundary}`,
+        pinata_api_key: PINATA_API_KEY,
+        pinata_secret_api_key: PINATA_API_SECRET,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Add metadata folder upload to Pinata. Use example of how BAYC was able to use the `CID/TokenID` IPFS path.